### PR TITLE
remove help-critical class from hidden div

### DIFF
--- a/wagtailreacttaxonomy/templates/wagtailadmin/panels/permissions_panel.html
+++ b/wagtailreacttaxonomy/templates/wagtailadmin/panels/permissions_panel.html
@@ -31,7 +31,7 @@
             </li>
         </ul>
         <div id="react-taxonomy-permissions">
-            <div class="help-block help-critical">React Taxonomy Permissions Component cannot be loaded</div>
+            <div class="help-block">React Taxonomy Permissions Component cannot be loaded</div>
         </div>
     </fieldset>
     <textarea id="permission-terms-json">{{permission_terms_json|safe}}</textarea>

--- a/wagtailreacttaxonomy/templates/wagtailadmin/panels/taxonomy_panel.html
+++ b/wagtailreacttaxonomy/templates/wagtailadmin/panels/taxonomy_panel.html
@@ -31,7 +31,7 @@
             </li>
         </ul>
         <div id="react-taxonomy">
-            <div class="help-block help-critical">React Taxonomy Component cannot be loaded</div>
+            <div class="help-block">React Taxonomy Component cannot be loaded</div>
         </div>
     </fieldset>
     <textarea id="taxonomy-terms-json">{{taxonomy_terms_json|safe}}</textarea>


### PR DESCRIPTION
This change removes the misleading alert/badge on the Taxonomy tab when there are no errors, detailed here: https://digitaltools.phe.org.uk/browse/CV-694

Before:
![image](https://github.com/nhsuk/wagtail-reacttaxonomy/assets/63047467/b88f93cd-40f0-41ee-b645-76000d07374c)


After:
![image](https://github.com/nhsuk/wagtail-reacttaxonomy/assets/63047467/7c1ace6f-9219-4177-ab6f-c1c3efc1a43d)
